### PR TITLE
Improve tailwind compile time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,3 @@ yarn-error.log
 
 # Yarn Integrity file
 .yarn-integrity
-
-# NPM
-package-lock.json

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,4 +4,7 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 
-// You can delete this file if you're not using it
+import './src/styles/tailwind.base.css'
+import './src/styles/tailwind.components.css'
+import './src/styles/index.css'
+import './src/styles/tailwind.utilities.css'

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -66,13 +66,14 @@ module.exports = {
       options: {
         // The plugin order matters
         postCssPlugins: [
+          require('stylelint'),
+          require('postcss-import'),
+          require('tailwindcss')('./tailwind.config.js'),
           require('postcss-extend-rule'),
           require('postcss-advanced-variables'),
           require('postcss-preset-env'), // Defaults to Stage 2
           require('postcss-atroot'),
           require('postcss-property-lookup'),
-          require('stylelint'),
-          require('tailwindcss')('./tailwind.config.js'),
           require('postcss-nested'),
           require('autoprefixer')(),
           require('postcss-reporter')({ clearReportedMessages: true }),

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "postcss-advanced-variables": "^3.0.0",
     "postcss-atroot": "^0.1.3",
     "postcss-extend-rule": "^3.0.0",
+    "postcss-import": "^12.0.1",
     "postcss-nested": "^4.1.2",
     "postcss-preset-env": "^6.7.0",
     "postcss-property-lookup": "^2.0.0",

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -4,8 +4,6 @@ import { StaticQuery, graphql } from 'gatsby'
 
 import Header from '../Header'
 
-import '../../styles/index.css'
-
 const Layout = ({ children }) => (
   <StaticQuery
     query={graphql`

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,10 +1,1 @@
-/* stylelint-disable */
-@tailwind base;
-@tailwind components;
-/* stylelint-enable */
-
 @import 'components/rte.css';
-
-/* stylelint-disable */
-@tailwind utilities;
-/* stylelint-enable */

--- a/src/styles/tailwind.base.css
+++ b/src/styles/tailwind.base.css
@@ -1,0 +1,3 @@
+/* stylelint-disable */
+@tailwind base;
+/* stylelint-enable */

--- a/src/styles/tailwind.components.css
+++ b/src/styles/tailwind.components.css
@@ -1,0 +1,3 @@
+/* stylelint-disable */
+@tailwind components;
+/* stylelint-enable */

--- a/src/styles/tailwind.utilities.css
+++ b/src/styles/tailwind.utilities.css
@@ -1,0 +1,3 @@
+/* stylelint-disable */
+@tailwind utilities;
+/* stylelint-enable */

--- a/yarn.lock
+++ b/yarn.lock
@@ -9744,6 +9744,16 @@ postcss-image-set-function@^3.0.1:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
+postcss-import@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-12.0.1.tgz#cf8c7ab0b5ccab5649024536e565f841928b7153"
+  integrity sha512-3Gti33dmCjyKBgimqGxL3vcV8w9+bsHwO5UrBawp796+jdardbcFl4RP5w/76BwNL7aGzpKstIfF9I+kdE8pTw==
+  dependencies:
+    postcss "^7.0.1"
+    postcss-value-parser "^3.2.3"
+    read-cache "^1.0.0"
+    resolve "^1.1.7"
+
 postcss-initial@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-3.0.1.tgz#99d319669a13d6c06ef8e70d852f68cb1b399b61"
@@ -10254,7 +10264,7 @@ postcss-unique-selectors@^4.0.1:
     postcss "^7.0.0"
     uniqs "^2.0.0"
 
-postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^3.3.1:
+postcss-value-parser@^3.0.0, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0, postcss-value-parser@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
@@ -10780,6 +10790,13 @@ react@^16.9.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
+read-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  integrity sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=
+  dependencies:
+    pify "^2.3.0"
+
 read-chunk@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-3.2.0.tgz#2984afe78ca9bfbbdb74b19387bf9e86289c16ca"
@@ -11245,6 +11262,13 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+
+resolve@^1.1.7:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.2.tgz#08b12496d9aa8659c75f534a8f05f0d892fff594"
+  integrity sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==
+  dependencies:
+    path-parse "^1.0.6"
 
 resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
   version "1.12.0"


### PR DESCRIPTION
Hey @thejoshsmith, 

I've made the changes here to improve the css compile time, which has been slowed down by the new tailwind extend functionality. To achieve a faster compile time I've split out tailwind imports into their own files:

- tailwind.base.css
- tailwind.components.css
- tailwind.utilities.css

I'm also importing all the css files into `gatsby-browser.js`, as recommend in the Gatsby docs:

```
import './src/styles/tailwind.base.css'
import './src/styles/tailwind.components.css'
import './src/styles/index.css'
import './src/styles/tailwind.utilities.css'
```

There's also the change to the `postCssPlugins` order to remove the.. 
```
You did not set any plugins, parser, or stringifier. Right now, PostCSS does nothing. Pick plugins for your case on https://www.postcss.parts/ and use them in postcss.config.js.
``` 
...warning.

Any questions let me know.